### PR TITLE
[Tutorial5] Relationships & Hyperlinked APIs

### DIFF
--- a/apps/snippets/urls.py
+++ b/apps/snippets/urls.py
@@ -6,15 +6,16 @@ from django.urls import path
 
 from rest_framework.urlpatterns import format_suffix_patterns
 
-from .views import UserList, UserDetail, SnippetList, SnippetDetail
+from .views import api_root, SnippetHighlight, UserList, UserDetail, SnippetList, SnippetDetail
 
 
-app_name = 'snippets'
-urlpatterns = [
-    path('', SnippetList.as_view()),
-    path('<int:pk>/', SnippetDetail.as_view()),
-    path('users/', UserList.as_view()),
-    path('users/<int:pk>/', UserDetail.as_view()),
-]
-
-urlpatterns = format_suffix_patterns(urlpatterns=urlpatterns)
+urlpatterns = format_suffix_patterns(urlpatterns=[
+    path(r'', api_root),
+    path(r'snippets/', SnippetList.as_view(), name='snippet-list'),
+    path(r'snippets/<int:pk>/', SnippetDetail.as_view(), name='snippet-detail'),
+    path(r'snippets/<int:pk>/highlight/',
+         SnippetHighlight.as_view(),
+         name='snippet-highlight'),  # Using HTML renderer from REST framework
+    path(r'users/', UserList.as_view(), name='snippet-user-list'),
+    path(r'users/<int:pk>/', UserDetail.as_view(), name='snippet-user-detail'),
+])

--- a/apps/snippets/views.py
+++ b/apps/snippets/views.py
@@ -23,9 +23,11 @@ from django.http import Http404
 from django.contrib.auth.models import User
 
 from rest_framework import status
+from rest_framework import renderers
 from rest_framework.views import APIView
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
+from rest_framework.reverse import reverse
 
 from rest_framework import mixins
 from rest_framework import generics
@@ -34,6 +36,40 @@ from rest_framework import permissions
 from .models import Snippet
 from .serializers import UserSerializer, SnippetSerializer
 from .permissions import IsOwnerOrReadOnly
+
+
+# Tutorial5: Single entry point for the snippet's root API
+# Tutorial5: Code highlighting endpoints using pre-rendered HTML plugin provided by REST framework.
+
+
+@api_view(['GET'])
+def api_root(request, format=None):
+    """
+    Single entry point to provide 'snippets' and 'users'.
+        :return:
+            Using REST framework's ```reverse``` function in order to return fully-qualified URLs.
+            and a URL patterns like specified below will also be declared in the ```snippets/urls.py``` module.
+    """
+    return Response({
+        'users': reverse('user-list', request=request, format=format),
+        'snippet-users': reverse('snippet-user-list', request=request, format=format),
+        'snippets': reverse('snippet-list', request=request, format=format),
+    })
+
+
+class SnippetHighlight(generics.GenericAPIView):
+    """
+    Code highlighting endpoint.
+        Instead of using a concrete generic view, we'll use the base class for representing instances,
+        and create our own ```.get()``` method.
+        We're not returning an object instance, but instead a property of an object instance.
+    """
+    queryset = Snippet.objects.all()
+    renderer_classes = [renderers.StaticHTMLRenderer]
+
+    def get(self, request, *args, **kwargs):
+        snippet = self.get_object()
+        return Response(snippet.highlighted)
 
 
 # CBV for user model

--- a/drftutorial/urls.py
+++ b/drftutorial/urls.py
@@ -17,8 +17,8 @@ from django.contrib import admin
 from django.urls import path, include
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('quickstart/', include('apps.quickstart.urls')),
-    path('snippets/', include('apps.snippets.urls', namespace='snippets')),
-    path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+    path(r'', include('apps.snippets.urls')),  # default app for this tutorial.
+    path(r'admin/', admin.site.urls),
+    path(r'quickstart/', include('apps.quickstart.urls')),
+    path(r'api-auth/', include('rest_framework.urls', namespace='rest_framework')),
 ]


### PR DESCRIPTION
1. ```snippets``` 앱의 ```serializer``` 를 **```HyperlinkedModelSerializer``` 타입**으로 변경하고 ```장고 Users``` 모델과 하이퍼링크 연동되도록 함
    - 하이퍼링크 기반 모델은 식별값을 **```url``` 필드**로 가지며 이를 통해 연관된 모델의 뷰로 쉽게 연결할 수 있다.
2. 스니펫 앱 내에서 **단일 접근 포인트용 뷰(```api_root```)**와 **코드 하이라이트 html 렌더링을 수행하는 별도 뷰**를 생성
    - ```api_root``` 는 장고의 ```reverse``` 기능을 이용해 직렬화된 스니펫과 사용자 모델 정보를 한 번에 제공함
    - highlight 뷰로 접근하면 ```pygments``` 스타일로 나타나는 code 를 html 로 렌더링해줌
3. ```snippets``` 앱을 프로젝트의 root path 로 세팅하고 앱 내 ```urls.py``` 일부 조정