### PR TITLE
[TEST] quickstart 앱에서 믹스인 이름을 UserTestMixin 에서 CreateTestUserMixin 으로 변경

### DIFF
--- a/apps/quickstart/tests/mixins.py
+++ b/apps/quickstart/tests/mixins.py
@@ -5,7 +5,7 @@ Mixins for quickstart app
 from django.contrib.auth.models import User
 
 
-class UserTestMixin(object):
+class CreateTestUserMixin(object):
     """
     Mixin for user test.
     """

--- a/apps/quickstart/tests/test_apis.py
+++ b/apps/quickstart/tests/test_apis.py
@@ -9,10 +9,10 @@ from django.contrib.auth.models import User, Group
 
 from apps.quickstart.serializers import UserSerializer, GroupSerializer
 
-from .mixins import UserTestMixin
+from .mixins import CreateTestUserMixin
 
 
-class BaseAPITestCase(UserTestMixin, APITestCase):
+class BaseAPITestCase(CreateTestUserMixin, APITestCase):
     """
     Base module for REST API test.
     """

--- a/apps/quickstart/tests/test_models.py
+++ b/apps/quickstart/tests/test_models.py
@@ -6,10 +6,10 @@ from django.test import TestCase
 
 from django.contrib.auth.models import User
 
-from .mixins import UserTestMixin
+from .mixins import CreateTestUserMixin
 
 
-class UserTest(UserTestMixin, TestCase):
+class UserTest(CreateTestUserMixin, TestCase):
     """
     Test module for Django User model.
     """


### PR DESCRIPTION
믹스인을 상속받는 하위 클래스에 제공되는 기능을 명시적으로 알려주기 위해서 변경함