### PR TITLE
[TEST] Modify the way setup method runs in quickstart app

### DIFF
--- a/apps/quickstart/tests/mixins.py
+++ b/apps/quickstart/tests/mixins.py
@@ -31,7 +31,3 @@ class CreateTestUserMixin(object):
         user = User(email=target_email, username=target_username)
         user.set_password(target_password)  # Set hashed password
         user.save()
-
-    def setUp(self) -> None:
-        """Setup default test user"""
-        self._create_test_user()

--- a/apps/quickstart/tests/test_apis.py
+++ b/apps/quickstart/tests/test_apis.py
@@ -1,5 +1,5 @@
 """
-Test views in quickstart app.
+Test APIs in quickstart app.
 """
 
 from rest_framework import status
@@ -21,8 +21,9 @@ class BaseAPITestCase(CreateTestUserMixin, APITestCase):
         abstract = True
 
     def setUp(self) -> None:
-        """Setup default test user"""
-        super(BaseAPITestCase, self).setUp()
+        """Setup default test user, authentication and request factory"""
+        # Create test user
+        self._create_test_user()
 
         # Set authentication for REST API call
         test_user = User.objects.get(username=self.username)
@@ -30,6 +31,8 @@ class BaseAPITestCase(CreateTestUserMixin, APITestCase):
 
         # Set request factory
         self.factory = APIRequestFactory()
+
+        super(BaseAPITestCase, self).setUp()
 
 
 class GetAndRetrieveTests(BaseAPITestCase):

--- a/apps/quickstart/tests/test_models.py
+++ b/apps/quickstart/tests/test_models.py
@@ -9,10 +9,16 @@ from django.contrib.auth.models import User
 from .mixins import CreateTestUserMixin
 
 
-class UserTest(CreateTestUserMixin, TestCase):
+class UserTests(CreateTestUserMixin, TestCase):
     """
     Test module for Django User model.
     """
+
+    def setUp(self) -> None:
+        """Setup default test user"""
+        self._create_test_user()
+
+        super(UserTests, self).setUp()
 
     def test_get_user(self) -> None:
         """User model test"""


### PR DESCRIPTION
- ```TestCase``` 클래스로부터 상속되는 ```setUp``` 메서드가 ```CreateTestUserMixin``` 에서 재정의되지 않도록 함.
- 믹스인은 단일 기능을 제공하도록 구현되어야 함..!
- ```setUp``` 메서드의 재정의는 ```TestCase``` 혹은 ```APITestCase``` 클래스를 상속받는 ```UserTests``` 와 ```BaseAPITestCase``` 추상클래스에서 이루어지도록 변경함
- ```BaseAPITestCase``` 추상 클래스는 DRF 의 api 테스트를 위해 인증 및 request factory 를 셋업함